### PR TITLE
Add LOW strata to health bars

### DIFF
--- a/ShadowedUnitFrames/modules/health.lua
+++ b/ShadowedUnitFrames/modules/health.lua
@@ -53,7 +53,8 @@ function Health:OnEnable(frame)
 	if( not frame.healthBar ) then
 		frame.healthBar = ShadowUF.Units:CreateBar(frame)
 	end
-	
+	frame:SetFrameStrata("LOW")
+
 	frame:RegisterUnitEvent("UNIT_HEALTH", self, "Update")
 	frame:RegisterUnitEvent("UNIT_MAXHEALTH", self, "Update")
 	frame:RegisterUnitEvent("UNIT_FACTION", self, "UpdateColor")


### PR DESCRIPTION
The strata was defaulting much higher than it should be and was overlapping with other frames such as the character pane.  This was applying to all bars including raid, player, and party.